### PR TITLE
Hiding the Quit button

### DIFF
--- a/views/index.haml
+++ b/views/index.haml
@@ -20,8 +20,6 @@
             %input{:type => 'search', :name => 'search', :placeholder => 'Search messages...', :incremental => true}
           %li.clear
             %a{:href => '#', :title => 'Clear all messages'} Clear
-          %li.quit
-            %a{:href => '#', :title => 'Quit MailCatcher'} Quit
     %nav#messages
       %table
         %thead


### PR DESCRIPTION
Ops often need to restart Mailcatcher processes that magically die.

Have just seen that the 'Quit' button top right kills the process - suspect that was being pressed by some people to exit the page and/or clear messages. This PR hides that button.